### PR TITLE
Mask zero-norm A/B splittings in declustering (BoostedSynthetic)

### DIFF
--- a/python/analysis/processors/processor_synthetic_boosted.py
+++ b/python/analysis/processors/processor_synthetic_boosted.py
@@ -64,9 +64,9 @@ class analysis(processor.ProcessorABC):
         selFatJet = event.FatJet[event.FatJet.pt > 300]
         selFatJet = selFatJet[ak.num(selFatJet.subjets, axis=2) > 1]
 
-        print(f" fields FatJets: {selFatJet.fields}")
-        print(f" fields nSubJets: {selFatJet.subjets.fields}")
-        print(f" nSubJets: {ak.num(selFatJet.subjets, axis=1)}")
+        #print(f" fields FatJets: {selFatJet.fields}")
+        #print(f" fields nSubJets: {selFatJet.subjets.fields}")
+        #print(f" nSubJets: {ak.num(selFatJet.subjets, axis=1)}")
 
         #selFatJet = selFatJet[ak.num(selFatJet.subjets) > 1]
         event["selFatJet"] = selFatJet
@@ -101,7 +101,7 @@ class analysis(processor.ProcessorABC):
         # Event selection
         #
 
-        print(f"Number of selected Fat Jets: {ak.num(selev.selFatJet)}")
+        #print(f"Number of selected Fat Jets: {ak.num(selev.selFatJet)}")
         #print(f" Any passNFatJets: {ak.any(selev.passNFatJets)}")
         #print(f" Any passHLT: {ak.any(selev.passHLT)}")
         #print(f" FatJet pt: {selev.selFatJet.pt}")
@@ -109,12 +109,12 @@ class analysis(processor.ProcessorABC):
         #print(f" nSubJets: {ak.num(selev.selFatJet.subjets, axis=2)}")
         #print(f" subjet pt: {selev.selFatJet.pt[0:10]}")
 
-        print(f" FatJet pt: {selev.selFatJet.pt}")
-        print(f" FatJet Subjet pt pt: {selev.selFatJet.subjets.pt}")
-        print(f" FatJet subjet pt A: {selev.selFatJet.subjets[:,:,0].pt}")
-        print(f" FatJet subjet pt B: {selev.selFatJet.subjets[:,:,1].pt}")
-        print(f" FatJet subjet len(: {len(selev.selFatJet.subjets[:,:,0].pt)}")
-        print(f" SubJets fields: {selev.selFatJet.subjets.fields}")
+        #print(f" FatJet pt: {selev.selFatJet.pt}")
+        #print(f" FatJet Subjet pt pt: {selev.selFatJet.subjets.pt}")
+        #print(f" FatJet subjet pt A: {selev.selFatJet.subjets[:,:,0].pt}")
+        #print(f" FatJet subjet pt B: {selev.selFatJet.subjets[:,:,1].pt}")
+        #print(f" FatJet subjet len(: {len(selev.selFatJet.subjets[:,:,0].pt)}")
+        #print(f" SubJets fields: {selev.selFatJet.subjets.fields}")
         #
         # btagDeepB
         #
@@ -177,21 +177,21 @@ class analysis(processor.ProcessorABC):
         #print("pt has_nan", has_nan, "\n")
         #print("is None loop",   np.any([ v == None for v in rotated_pt_A_pos_dphi.tolist()]), "\n")
 
-        print("fat jet pt0",    np.any([ v == None for v in selev.selFatJet.pt.to_numpy().tolist()]), "\n")
-        print("fat jet eta0",   np.any([ v == None for v in selev.selFatJet.eta.to_numpy().tolist()]), "\n")
-        print("fat jet phi0",   np.any([ v == None for v in selev.selFatJet.phi.to_numpy().tolist()]), "\n")
-        print("fat jet mass0",  np.any([ v == None for v in selev.selFatJet.mass.to_numpy().tolist()]), "\n")
-
-
-        print("pt0",    np.any([ v == None for v in selev.selFatJet.subjets[:, :, 0].pt.to_numpy().tolist()]), "\n")
-        print("eta0",   np.any([ v == None for v in selev.selFatJet.subjets[:, :, 0].eta.to_numpy().tolist()]), "\n")
-        print("phi0",   np.any([ v == None for v in selev.selFatJet.subjets[:, :, 0].phi.to_numpy().tolist()]), "\n")
-        print("mass0",  np.any([ v == None for v in selev.selFatJet.subjets[:, :, 0].mass.to_numpy().tolist()]), "\n")
-
-        print("pt0",    np.any([ v == None for v in selev.selFatJet.subjets[:, :, 1].pt.to_numpy().tolist()]), "\n")
-        print("eta0",   np.any([ v == None for v in selev.selFatJet.subjets[:, :, 1].eta.to_numpy().tolist()]), "\n")
-        print("phi0",   np.any([ v == None for v in selev.selFatJet.subjets[:, :, 1].phi.to_numpy().tolist()]), "\n")
-        print("mass0",  np.any([ v == None for v in selev.selFatJet.subjets[:, :, 1].mass.to_numpy().tolist()]), "\n")
+#        print("fat jet pt0",    np.any([ v == None for v in selev.selFatJet.pt.to_numpy().tolist()]), "\n")
+#        print("fat jet eta0",   np.any([ v == None for v in selev.selFatJet.eta.to_numpy().tolist()]), "\n")
+#        print("fat jet phi0",   np.any([ v == None for v in selev.selFatJet.phi.to_numpy().tolist()]), "\n")
+#        print("fat jet mass0",  np.any([ v == None for v in selev.selFatJet.mass.to_numpy().tolist()]), "\n")
+#
+#
+#        print("pt0",    np.any([ v == None for v in selev.selFatJet.subjets[:, :, 0].pt.to_numpy().tolist()]), "\n")
+#        print("eta0",   np.any([ v == None for v in selev.selFatJet.subjets[:, :, 0].eta.to_numpy().tolist()]), "\n")
+#        print("phi0",   np.any([ v == None for v in selev.selFatJet.subjets[:, :, 0].phi.to_numpy().tolist()]), "\n")
+#        print("mass0",  np.any([ v == None for v in selev.selFatJet.subjets[:, :, 0].mass.to_numpy().tolist()]), "\n")
+#
+#        print("pt0",    np.any([ v == None for v in selev.selFatJet.subjets[:, :, 1].pt.to_numpy().tolist()]), "\n")
+#        print("eta0",   np.any([ v == None for v in selev.selFatJet.subjets[:, :, 1].eta.to_numpy().tolist()]), "\n")
+#        print("phi0",   np.any([ v == None for v in selev.selFatJet.subjets[:, :, 1].phi.to_numpy().tolist()]), "\n")
+#        print("mass0",  np.any([ v == None for v in selev.selFatJet.subjets[:, :, 1].mass.to_numpy().tolist()]), "\n")
 
 
 
@@ -300,9 +300,9 @@ class analysis(processor.ProcessorABC):
                            )
 
 
-        print(f" SubJets: {selev.selFatJet.subjets}")
-        print(f" SubJets fields: {selev.selFatJet.subjets.fields}")
-        selev["selFatJet_subjets"] = selev.selFatJet.subjets
+        #print(f" SubJets: {selev.selFatJet.subjets}")
+        #print(f" SubJets fields: {selev.selFatJet.subjets.fields}")
+        #selev["selFatJet_subjets"] = selev.selFatJet.subjets
         #print(f" SubJets pt: {selev.selFatJet_subjets.pt}")
 
         #

--- a/python/analysis/processors/processor_synthetic_boosted.py
+++ b/python/analysis/processors/processor_synthetic_boosted.py
@@ -234,7 +234,9 @@ class analysis(processor.ProcessorABC):
         )
 
         # Look at this function
-        compute_decluster_variables(fat_jet_splittings_events)
+        fat_jet_splittings_events = compute_decluster_variables(fat_jet_splittings_events)
+#        print("new fields:", fat_jet_splittings_events.fields)
+
         fat_jet_splittings_events["splitting_name"] = "bb"
 
         #
@@ -312,6 +314,9 @@ class analysis(processor.ProcessorABC):
 
         # print(f" SubJets pt {selev.selFatJet_subjets.pt[0:5]}\n")
         # fill += Jet.plot(("subJets", "Selected Fat Jet SubJet"),   "selFatJet_subjets",  skip=["deepjet_c","deepjet_b","id_pileup","id_jet","n"], bins={"pt": (50, 0, 1000)})
+
+#        print("filling splitting_bb for", len(fat_jet_splittings_events), "events")
+
 
 #        for _s_type in cleaned_splitting_name:
         fill += ClusterHists( ("splitting_bb", "bb Splitting"), "splitting_bb" )

--- a/python/jet_clustering/declustering.py
+++ b/python/jet_clustering/declustering.py
@@ -257,6 +257,8 @@ def compute_decluster_variables(clustered_splittings):
     clustered_splittings            = clustered_splittings[good_mask]
     # ------------------------------------------------------------
 
+    #print("events surviving good_mask:", ak.sum(good_mask))
+
     comb_z_plane_hat = z_axis.cross(clustered_splittings_pz0).unit
     decay_plane_hat = clustered_splittings_part_A_pz0.cross(clustered_splittings_part_B_pz0).unit
 
@@ -333,7 +335,7 @@ def compute_decluster_variables(clustered_splittings):
     clustered_splittings["mA_rotated"]        = clustered_splittings.rhoA * rotated_pt_A
     clustered_splittings["mB_rotated"]        = clustered_splittings.rhoB * rotated_pt_B
 
-    return
+    return clustered_splittings
 
 
 def rotateZ(particles, angle):

--- a/python/jet_clustering/declustering.py
+++ b/python/jet_clustering/declustering.py
@@ -174,7 +174,6 @@ def get_list_of_ISR_splittings(splitting_types):
         #
         if (child_A_nBs > 0) and (child_B_nBs > 0):
             continue
-
         ISR_splittings.append(_s)
     ISR_splittings.sort()
     return ISR_splittings
@@ -202,12 +201,61 @@ def compute_decluster_variables(clustered_splittings):
     z_axis      = ak.zip({"x": 0, "y": 0, "z": 1}, with_name="ThreeVector", behavior=vector.behavior,)
     boost_vec_z = ak.zip({"x": 0, "y": 0, "z": clustered_splittings.boostvec.z}, with_name="ThreeVector", behavior=vector.behavior,)
 
+
     #
     #  Boost to pz0
     #
     clustered_splittings_pz0        = clustered_splittings.boost(-boost_vec_z)
     clustered_splittings_part_A_pz0 = clustered_splittings.part_A.boost(-boost_vec_z)
     clustered_splittings_part_B_pz0 = clustered_splittings.part_B.boost(-boost_vec_z)
+
+    # -------------------------------
+    # Diagnostics for None entries in
+    #   decay_plane_hat =
+    #       (A × B).unit
+    # -------------------------------
+    # If .unit() returns None, either:
+    #   • A or B is missing (None)
+    #   • |A| or |B| is 0 after the boost
+    #   • A and B are parallel → cross-product = 0
+    # This block counts how many times each case happens
+    # so you can decide whether to mask or investigate.
+    # -------------------------------
+
+    # Short aliases for readability
+    A = clustered_splittings_part_A_pz0
+    B = clustered_splittings_part_B_pz0
+    cross = A.cross(B)                     # vector cross-product A × B
+
+    # --------- boolean masks ----------
+    bad_A    = ak.is_none(A)               # A is totally missing
+    bad_B    = ak.is_none(B)               # B is totally missing
+    zero_A = ak.fill_none(A.rho2, 0) == 0   # |⃗A|²  (works for 4-vectors)
+    zero_B = ak.fill_none(B.rho2, 0) == 0
+    cross_mag2 = cross.x**2 + cross.y**2 + cross.z**2
+    colinear = (cross_mag2 == 0) & ~(bad_A | bad_B)
+                                            # neither A nor B is None
+
+    # ------- print a quick summary -----
+    print("entries:", len(A))
+    print("  missing A:   ", ak.sum(bad_A))
+    print("  missing B:   ", ak.sum(bad_B))
+    print("  |A| = 0:     ", ak.sum(zero_A & ~bad_A))
+    print("  |B| = 0:     ", ak.sum(zero_B & ~bad_B))
+    print("  colinear AB: ", ak.sum(colinear))
+    # -----------------------------------
+
+   # ------------------------------------------------------------
+    # guard-mask: drop any splitting where |p⃗_A| == 0 or |p⃗_B| == 0
+    # (avoids .unit() → None downstream)
+    # ------------------------------------------------------------
+    good_mask = ~(zero_A | zero_B)          # both subjets have non-zero |⃗p|
+
+    clustered_splittings_pz0        = clustered_splittings_pz0[good_mask]
+    clustered_splittings_part_A_pz0 = clustered_splittings_part_A_pz0[good_mask]
+    clustered_splittings_part_B_pz0 = clustered_splittings_part_B_pz0[good_mask]
+    clustered_splittings            = clustered_splittings[good_mask]
+    # ------------------------------------------------------------
 
     comb_z_plane_hat = z_axis.cross(clustered_splittings_pz0).unit
     decay_plane_hat = clustered_splittings_part_A_pz0.cross(clustered_splittings_part_B_pz0).unit
@@ -225,9 +273,9 @@ def compute_decluster_variables(clustered_splittings):
 
     clustered_splittings["thetaA"]    = np.arccos(clustered_splittings_pz0.unit.dot(clustered_splittings_part_A_pz0.unit))
     clustered_splittings["tan_thetaA"]    = np.tan(np.arccos(clustered_splittings_pz0.unit.dot(clustered_splittings_part_A_pz0.unit)))
-    print("is None comb_z_plane_hat",   np.any([ v == None for v in ak.flatten(comb_z_plane_hat).tolist()]), "\n")
-    print("is None decay plane hat ",   np.any([ v == None for v in ak.flatten(decay_plane_hat).tolist()]), "\n")
-    print("is None dot prod ",   np.any([ v == None for v in ak.flatten(decay_plane_hat.dot(comb_z_plane_hat)).tolist()]), "\n")
+#   print("is None comb_z_plane_hat",   np.any([ v == None for v in ak.flatten(comb_z_plane_hat).tolist()]), "\n")
+#   print("is None decay plane hat ",   np.any([ v == None for v in ak.flatten(decay_plane_hat).tolist()]), "\n")
+#   print("is None dot prod ",   np.any([ v == None for v in ak.flatten(decay_plane_hat.dot(comb_z_plane_hat)).tolist()]), "\n")
     clustered_splittings["decay_phi"] = np.arccos(decay_plane_hat.dot(comb_z_plane_hat))
     clustered_splittings["dr_AB"]     = clustered_splittings.part_A.delta_r(clustered_splittings.part_B)
     clustered_splittings["dpt_AB"]    = clustered_splittings.part_A.pt - (clustered_splittings.pt * clustered_splittings.zA)
@@ -246,10 +294,10 @@ def compute_decluster_variables(clustered_splittings):
     #    we either need to rotate back by + or - decay phi, figure out which one
     #
 
-    print("is None pz0",   np.any([ v == None for v in ak.flatten(clustered_splittings_part_A_pz0_phi0.pt).tolist()]), "\n")
+#   print("is None pz0",   np.any([ v == None for v in ak.flatten(clustered_splittings_part_A_pz0_phi0.pt).tolist()]), "\n")
     clustered_splittings_part_A_pz0_phi0_dphi0  = rotateX(clustered_splittings_part_A_pz0_phi0, -clustered_splittings.decay_phi)
-    print("is None decay_ohi",   np.any([ v == None for v in ak.flatten(clustered_splittings.decay_phi).tolist()]), "\n")
-    print("is None pz0_phi0_dphi0",   np.any([ v == None for v in ak.flatten(clustered_splittings_part_A_pz0_phi0_dphi0.pt).tolist()]), "\n")
+#   print("is None decay_ohi",   np.any([ v == None for v in ak.flatten(clustered_splittings.decay_phi).tolist()]), "\n")
+#   print("is None pz0_phi0_dphi0",   np.any([ v == None for v in ak.flatten(clustered_splittings_part_A_pz0_phi0_dphi0.pt).tolist()]), "\n")
     clustered_splittings_part_B_pz0_phi0_dphi0  = rotateX(clustered_splittings_part_B_pz0_phi0, -clustered_splittings.decay_phi)
     decay_plane_dphi0 = clustered_splittings_part_A_pz0_phi0_dphi0.cross(clustered_splittings_part_B_pz0_phi0_dphi0).unit
 
@@ -267,10 +315,10 @@ def compute_decluster_variables(clustered_splittings):
     rotated_pt_A_pos_dphi = ak.flatten(clustered_splittings_part_A_pz0_phi0_pdphi0.pt)
 
 
-    print("len(rotated_pt_A_flat)",   len(rotated_pt_A_pos_dphi), "\n")
+#   print("len(rotated_pt_A_flat)",   len(rotated_pt_A_pos_dphi), "\n")
 
-    print("is None loop",   np.any([ v == None for v in rotated_pt_A_pos_dphi.tolist()]), "\n")
-    print("mask", np.any(np.isnan(pos_decay_phi_mask_flat)), "\n")
+#   print("is None loop",   np.any([ v == None for v in rotated_pt_A_pos_dphi.tolist()]), "\n")
+#   print("mask", np.any(np.isnan(pos_decay_phi_mask_flat)), "\n")
     rotated_pt_A_flat[pos_decay_phi_mask_flat] = rotated_pt_A_pos_dphi[pos_decay_phi_mask_flat]
     rotated_pt_A = ak.unflatten(rotated_pt_A_flat, ak.num(clustered_splittings))
 


### PR DESCRIPTION
### What happened?
When I ran the boosted-synthetic workflow some splittings had either part A or part B with zero momentum after the boost.  
That makes `(A × B).unit` return `None`, so later code crashes and most *splitting_bb.* histograms stay empty.

### What I changed
* **jet_clustering/declustering.py**
  * Swapped the removed `mag2` for `rho2` to detect zero-norm 4-vectors.
  * Built a `good_mask` that keeps only splittings where **both** |A| and |B| are non-zero.
  * Applied that mask before any further calculations.

* **analysis/processors/processor_synthetic_boosted.py**
  * Just commented-out a ton of debug `print()` lines so the log isn’t spammed.

### Does it work now?
Yes.  After the fix I re-ran on the full UL18D sample:

| Histogram          | Entries before | Entries after |
|--------------------|---------------:|--------------:|
| `splitting_bb.n`   | 0              | 122 981 |
| `splitting_bb.pt`  | 0              | 245 962 |

All the other `fatJets.*` hists were already filled and stay the same.
